### PR TITLE
Updated depends and exported createTypeboxSchema

### DIFF
--- a/fastify+3.14.0.patch
+++ b/fastify+3.14.0.patch
@@ -1,10 +1,10 @@
 diff --git a/node_modules/fastify/types/instance.d.ts b/node_modules/fastify/types/instance.d.ts
-index 06380bd..558338d 100644
+index 67d6930..0cacd78 100644
 --- a/node_modules/fastify/types/instance.d.ts
 +++ b/node_modules/fastify/types/instance.d.ts
-@@ -66,14 +66,14 @@ export interface FastifyInstance<
-     ContextConfig = ContextConfigDefault
-   >(opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+@@ -68,14 +68,14 @@ export interface FastifyInstance<
+     SchemaCompiler = FastifySchema,
+   >(opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler>): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
  
 -  get: RouteShorthandMethod<RawServer, RawRequest, RawReply>;
 -  head: RouteShorthandMethod<RawServer, RawRequest, RawReply>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,5 +53,6 @@ declare module "fastify" {
     }
 }
 declare const createTypeboxSchema: <T extends Schema>(typeboxSchema: T) => T;
-declare const _default: import("fastify").FastifyPluginCallback<{}, import("http").Server>;
+declare const _default: import("fastify").FastifyPluginCallback<Record<never, never>, import("http").Server>;
 export default _default;
+export { createTypeboxSchema };

--- a/index.js
+++ b/index.js
@@ -3,8 +3,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.createTypeboxSchema = void 0;
 var fastify_plugin_1 = __importDefault(require("fastify-plugin"));
 var createTypeboxSchema = function (typeboxSchema) { return typeboxSchema; };
+exports.createTypeboxSchema = createTypeboxSchema;
 var plugin = function (fastify, _options, done) {
     fastify.decorate("typeboxSchema", createTypeboxSchema);
     done();

--- a/index.ts
+++ b/index.ts
@@ -119,3 +119,4 @@ const plugin: FastifyPlugin = (fastify, _options, done) => {
 };
 
 export default fp(plugin, { fastify: ">=3.x", name: "@foodsy-app/fastify-typebox" });
+export { createTypeboxSchema };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,27 +4,43 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@fastify/forwarded": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-1.0.0.tgz",
+      "integrity": "sha512-VoO+6WD0aRz8bwgJZ8pkkxjq7o/782cQ1j945HWg0obZMgIadYW3Pew0+an+k1QL7IPZHM3db5WF6OP6x4ymMA==",
+      "dev": true
+    },
+    "@fastify/proxy-addr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-3.0.0.tgz",
+      "integrity": "sha512-ty7wnUd/GeSqKTC2Jozsl5xGbnxUnEFC0On2/zPv/8ixywipQmVZwuWvNGnBoitJ2wixwVqofwXNua8j6Y62lQ==",
+      "dev": true,
+      "requires": {
+        "@fastify/forwarded": "^1.0.0",
+        "ipaddr.js": "^2.0.0"
+      }
+    },
     "@sinclair/typebox": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.10.1.tgz",
-      "integrity": "sha512-IZK7ao3ef92oZ5TjTwjVm9Xx65P2rj3frp7Fc58qy+pN+EL5gtv9mJWSQ5lcUWOWKNIOeOdTYjMPhg86rWGq2Q=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.16.0.tgz",
+      "integrity": "sha512-+5ucTvISuUyxE4yvSjpx5vZWThK/ya0MbOIgwxfhEdZSZje0v1xiGuZWAA/7/dcalu8WGKGopyf5fsHF4giiEg=="
     },
     "@types/node": {
-      "version": "14.0.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.24.tgz",
-      "integrity": "sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==",
+      "version": "14.14.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
+      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
       "dev": true
     },
     "abstract-logging": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.0.tgz",
-      "integrity": "sha512-/oA9z7JszpIioo6J6dB79LVUgJ3eD3cxkAmdCkvWWS+Y9tPtALs1rLqOekLUXUbYqM2fB9TTK0ibAyZJJOP/CA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "dev": true
     },
     "ajv": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -46,9 +62,9 @@
       "dev": true
     },
     "avvio": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/avvio/-/avvio-7.1.2.tgz",
-      "integrity": "sha512-mzJqhylHN4u5VeUWt4Vol4u8lhOFJMZmdE+GR0vP4Ea6Fg36m5b0e4zy8FCBD+dcagbOxSgfMSJ48jxELduk7w==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-7.2.1.tgz",
+      "integrity": "sha512-b+gox68dqD6c3S3t+bZBKN6rYbVWdwpN12sHQLFTiacDT2rcq7fm07Ww+IKt/AvAkyCIe1f5ArP1bC/vAlx97A==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
@@ -83,12 +99,12 @@
       "dev": true
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "deepmerge": {
@@ -116,20 +132,21 @@
       "dev": true
     },
     "fast-json-stringify": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.2.3.tgz",
-      "integrity": "sha512-5VT2l3XUORCxkeVCvrcUqfoEIIzuop1lxwwT/THlOkAfrhlIuriWXdFGKU2hZQxz0KOiWSYoZTatumGYCXfAlA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.5.2.tgz",
+      "integrity": "sha512-H0/Wq7jj/i96DycCySdh+Jl0MubqaScM51GJkdJmjzwyiNpxAgQ9deYqk2H8SNOfwPj21RtTXMkMV5GosUWKeQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.11.0",
         "deepmerge": "^4.2.2",
+        "rfdc": "^1.2.0",
         "string-similarity": "^4.0.1"
       }
     },
     "fast-redact": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
-      "integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
+      "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w==",
       "dev": true
     },
     "fast-safe-stringify": {
@@ -139,57 +156,63 @@
       "dev": true
     },
     "fastify": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.1.1.tgz",
-      "integrity": "sha512-A7kBZIFAdpE/8MZ9qHpQV9IVPpfX63uWMaPN4p0fetax10C2p56iV/VEB5hOgtlXzayGn+4tf+tNHcZsfrjlnA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.14.0.tgz",
+      "integrity": "sha512-a6W2iVPJMOaULqCykJ5nFRtnoknqt9K3b6rqAQcGjT/O2Hy+vvo+9/+cL2907KN0iF/91Ke+XQluKrVNF6+Z7w==",
       "dev": true,
       "requires": {
+        "@fastify/proxy-addr": "^3.0.0",
         "abstract-logging": "^2.0.0",
         "ajv": "^6.12.2",
         "avvio": "^7.1.2",
-        "fast-json-stringify": "^2.2.1",
-        "fastify-error": "^0.1.0",
-        "find-my-way": "^3.0.0",
+        "fast-json-stringify": "^2.5.0",
+        "fastify-error": "^0.3.0",
+        "fastify-warning": "^0.2.0",
+        "find-my-way": "^4.0.0",
         "flatstr": "^1.0.12",
-        "light-my-request": "^4.0.0",
+        "light-my-request": "^4.2.0",
         "pino": "^6.2.1",
-        "proxy-addr": "^2.0.5",
         "readable-stream": "^3.4.0",
         "rfdc": "^1.1.4",
         "secure-json-parse": "^2.0.0",
+        "semver": "^7.3.2",
         "tiny-lru": "^7.0.0"
       }
     },
     "fastify-error": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/fastify-error/-/fastify-error-0.1.0.tgz",
-      "integrity": "sha512-jyCEc3VPEc8/PUwzDQAM2JlXLK2BG6L19mMJzbGij0TfdY1sHF9pCnnAn6Vcoi84TMTBOJynNDQUMUz6cjRmBw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/fastify-error/-/fastify-error-0.3.0.tgz",
+      "integrity": "sha512-Jm2LMTB5rsJqlS1+cmgqqM9tTs0UrlgYR7TvDT3ZgXsUI5ib1NjQlqZHf+tDK5tVPdFGwyq02wAoJtyYIRSiFA==",
       "dev": true
     },
     "fastify-plugin": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-2.0.1.tgz",
-      "integrity": "sha512-spYlahs74ZHR/s+cPXukJLwx0B6khgnX05i2rZW5lc9dqoMI0txrNA9mGruulkerqd4FduzkZMTQJywSwkiVOw==",
-      "requires": {
-        "semver": "^7.3.2"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-3.0.0.tgz",
+      "integrity": "sha512-ZdCvKEEd92DNLps5n0v231Bha8bkz1DjnPP/aEz37rz/q42Z5JVLmgnqR4DYuNn3NXAO3IDCPyRvgvxtJ4Ym4w=="
+    },
+    "fastify-warning": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fastify-warning/-/fastify-warning-0.2.0.tgz",
+      "integrity": "sha512-s1EQguBw/9qtc1p/WTY4eq9WMRIACkj+HTcOIK1in4MV5aFaQC9ZCIt0dJ7pr5bIf4lPpHvAtP2ywpTNgs7hqw==",
+      "dev": true
     },
     "fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
       }
     },
     "find-my-way": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-3.0.5.tgz",
-      "integrity": "sha512-FweGg0cv1sBX8z7WhvBX5B5AECW4Zdh/NiB38Oa0qwSNIyPgRBCl/YjxuZn/rz38E/MMBHeVKJ22i7W3c626Gg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-4.0.0.tgz",
+      "integrity": "sha512-IrICzn/Xm5r5A3RCB8rGLNe+dvzZl+SiUugTQOUMLJciP2qiSu2hw9JtVEYV3VruAYzSWjo/MLH9CFKtVdlWhQ==",
       "dev": true,
       "requires": {
         "fast-decode-uri-component": "^1.0.1",
+        "fast-deep-equal": "^3.1.3",
         "safe-regex2": "^2.0.0",
         "semver-store": "^0.3.0"
       }
@@ -198,12 +221,6 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
       "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
-      "dev": true
-    },
-    "forwarded": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
     "fs.realpath": {
@@ -239,9 +256,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.0.tgz",
+      "integrity": "sha512-S54H9mIj0rbxRIyrDMEuuER86LdlgUg9FSeZ8duQb6CUG2iRrA36MYVQBSprTF/ZeAwvyQ5mDGuNvIPM0BIl3w==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -251,15 +268,25 @@
       "dev": true
     },
     "light-my-request": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-4.0.1.tgz",
-      "integrity": "sha512-kGRfzvSS9P/zEsnu34pUisOz2FAPqkHFJfdezW6HRzLLlzjY+1LTRRuh2d82SkW/M/QWNVWnXTZ0HMUydz2fgg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-4.4.1.tgz",
+      "integrity": "sha512-FDNRF2mYjthIRWE7O8d/X7AzDx4otQHl4/QXbu3Q/FRwBFcgb+ZoDaUd5HwN53uQXLAiw76osN+Va0NEaOW6rQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.2",
         "cookie": "^0.4.0",
+        "fastify-warning": "^0.2.0",
         "readable-stream": "^3.6.0",
         "set-cookie-parser": "^2.4.1"
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
       }
     },
     "minimatch": {
@@ -290,34 +317,24 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "pino": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.4.0.tgz",
-      "integrity": "sha512-TRDp5fJKRBtVlxd4CTox3rJL+TzwQztB/VNmT5n87zFgKVU7ztnmZkcX1zypPP+3ZZcveOTYKJy74UXdVBaXFQ==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.11.2.tgz",
+      "integrity": "sha512-bmzxwbrIPxQUlAuMkF4PWVErUGERU4z37HazlhflKFg08crsNE3fACGN6gPwg5xtKOK47Ux5cZm8YCuLV4wWJg==",
       "dev": true,
       "requires": {
-        "fast-redact": "^2.0.0",
+        "fast-redact": "^3.0.0",
         "fast-safe-stringify": "^2.0.7",
         "flatstr": "^1.0.12",
-        "pino-std-serializers": "^2.4.2",
-        "quick-format-unescaped": "^4.0.1",
-        "sonic-boom": "^1.0.0"
+        "pino-std-serializers": "^3.1.0",
+        "quick-format-unescaped": "4.0.1",
+        "sonic-boom": "^1.0.2"
       }
     },
     "pino-std-serializers": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
-      "integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==",
       "dev": true
-    },
-    "proxy-addr": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
-      "dev": true,
-      "requires": {
-        "forwarded": "~0.1.2",
-        "ipaddr.js": "1.9.1"
-      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -326,9 +343,9 @@
       "dev": true
     },
     "queue-microtask": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.4.tgz",
-      "integrity": "sha512-eY/4Obve9cE5FK8YvC1cJsm5cr7XvAurul8UtBDJ2PR1p5NmAwHtvAt5ftcLtwYRCUKNhxCneZZlxmUDFoSeKA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
     "quick-format-unescaped": {
@@ -361,9 +378,9 @@
       "dev": true
     },
     "rfdc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
-      "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
       "dev": true
     },
     "rimraf": {
@@ -390,15 +407,19 @@
       }
     },
     "secure-json-parse": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.1.0.tgz",
-      "integrity": "sha512-GckO+MS/wT4UogDyoI/H/S1L0MCcKS1XX/vp48wfmU7Nw4woBmb8mIpu4zPBQjKlRT88/bt9xdoV4111jPpNJA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.3.2.tgz",
+      "integrity": "sha512-4oUSFU0w2d8/XQb7NO9dbMYyp/hxIwZPcZcGAlAAEziMRHs+NbUcx2Z5dda/z8o+avyQ8gpuYnTMlGh8SVwg9g==",
       "dev": true
     },
     "semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "semver-store": {
       "version": "0.3.0",
@@ -407,15 +428,15 @@
       "dev": true
     },
     "set-cookie-parser": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.6.tgz",
-      "integrity": "sha512-mNCnTUF0OYPwYzSHbdRdCfNNHqrne+HS5tS5xNb6yJbdP9wInV0q5xPLE0EyfV/Q3tImo3y/OXpD8Jn0Jtnjrg==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
+      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
       "dev": true
     },
     "sonic-boom": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.0.2.tgz",
-      "integrity": "sha512-sRMmXu7uFDXoniGvtLHuQk5KWovLWoi6WKASn7rw0ro41mPf0fOolkGp4NE6680CbxvNh26zWNyFQYYWXe33EA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.0.tgz",
+      "integrity": "sha512-1xUAszhQBOrjk7uisbStQZYkZxD3vkYlCUw5qzOblWQ1ILN5v0dVPAs+QPgszzoPmbdWx6jyT9XiLJ95JdlLiQ==",
       "dev": true,
       "requires": {
         "atomic-sleep": "^1.0.0",
@@ -423,9 +444,9 @@
       }
     },
     "string-similarity": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.1.tgz",
-      "integrity": "sha512-v36MJzloekKVvKAsYi6O/qpn2mIuvwEFIT9Gx3yg4spkNjXYsk7yxc37g4ZTyMVIBvt/9PZGxnqEtme8XHK+Mw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
+      "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
       "dev": true
     },
     "string_decoder": {
@@ -444,15 +465,15 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
       "dev": true
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -468,6 +489,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,17 +30,18 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf index.js index.d.ts",
-    "prepublishOnly": "npm run clean && npm run build"
+    "prepublishOnly": "npm run clean && npm run build",
+    "postinstall": "npx patch-package --patch-dir ."
   },
   "dependencies": {
-    "@sinclair/typebox": "^0.10.1",
-    "fastify-plugin": "^2.0.1",
+    "@sinclair/typebox": "^0.16.0",
+    "fastify-plugin": "^3.0.0",
     "rimraf": "^3.0.2"
   },
   "devDependencies": {
-    "@types/node": "^14.0.24",
-    "fastify": "^3.1.1",
-    "typescript": "^3.9.7"
+    "@types/node": "^14.14.35",
+    "fastify": "^3.14.0",
+    "typescript": "^4.2.3"
   },
   "engines": {
     "node": ">=5"


### PR DESCRIPTION
The main reason for this MR is to expose `createTypeboxSchema` function. This is because it has no hard connection to the Fastify server and thus can be used in files where the Fastify server is not defined. E.g. a schema file.

The MR does not introduce any API changes so a simple minor version increment should suffice.

I took the opportunity to update the dependencies as well :)