### PR TITLE
Type improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ server.get(
     }),
   },
   (request, reply) => {
-    // `id` is inferred as string | undefined
-    const id = request.params?.id;
+    // `id` is inferred as string
+    const id = request.params.id;
 
     // `user` is inferred as the object we described!
-    const user = request.body?.user;
+    const user = request.body.user;
   }
 );
 ```

--- a/fastify+3.14.0.patch
+++ b/fastify+3.14.0.patch
@@ -1,11 +1,17 @@
 diff --git a/node_modules/fastify/types/instance.d.ts b/node_modules/fastify/types/instance.d.ts
-index 67d6930..0cacd78 100644
+index 67d6930..60b7916 100644
 --- a/node_modules/fastify/types/instance.d.ts
 +++ b/node_modules/fastify/types/instance.d.ts
-@@ -68,14 +68,14 @@ export interface FastifyInstance<
-     SchemaCompiler = FastifySchema,
-   >(opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler>): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+@@ -62,20 +62,20 @@ export interface FastifyInstance<
+   getDefaultRoute: DefaultRoute<RawRequest, RawReply>;
+   setDefaultRoute(defaultRoute: DefaultRoute<RawRequest, RawReply>): void;
  
+-  route<
+-    RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
+-    ContextConfig = ContextConfigDefault,
+-    SchemaCompiler = FastifySchema,
+-  >(opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler>): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+-
 -  get: RouteShorthandMethod<RawServer, RawRequest, RawReply>;
 -  head: RouteShorthandMethod<RawServer, RawRequest, RawReply>;
 -  post: RouteShorthandMethod<RawServer, RawRequest, RawReply>;
@@ -14,6 +20,12 @@ index 67d6930..0cacd78 100644
 -  options: RouteShorthandMethod<RawServer, RawRequest, RawReply>;
 -  patch: RouteShorthandMethod<RawServer, RawRequest, RawReply>;
 -  all: RouteShorthandMethod<RawServer, RawRequest, RawReply>;
++  // route<
++  //   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
++  //   ContextConfig = ContextConfigDefault,
++  //   SchemaCompiler = FastifySchema,
++  // >(opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler>): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
++
 +  // get: RouteShorthandMethod<RawServer, RawRequest, RawReply>;
 +  // head: RouteShorthandMethod<RawServer, RawRequest, RawReply>;
 +  // post: RouteShorthandMethod<RawServer, RawRequest, RawReply>;

--- a/index.ts
+++ b/index.ts
@@ -20,17 +20,17 @@ interface Schema extends FastifySchema {
   querystring?: TSchema;
   params?: TSchema;
   headers?: TSchema;
-  response?: {
-    [code: string]: TSchema;
-    [code: number]: TSchema;
-  };
+  response?: Record<number, TSchema>;
 }
+
+type StaticResponse<T> = T extends Record<string | number, infer U> ? Static<U> : never;
 
 export interface InferredRouteInterface<T extends Schema> {
   Body: Static<T["body"]>;
   Querystring: Static<T["querystring"]>;
   Params: Static<T["params"]>;
   Headers: Static<T["headers"]>;
+  Reply: StaticResponse<T["response"]>;
 }
 
 interface TypeboxRouteShorthandMethod<

--- a/index.ts
+++ b/index.ts
@@ -33,10 +33,10 @@ interface TypeboxRouteShorthandMethod<
   <
     T extends Schema,
     RequestGeneric extends {
-      Body?: Static<T["body"]>;
-      Querystring?: Static<T["querystring"]>;
-      Params?: Static<T["params"]>;
-      Headers?: Static<T["headers"]>;
+      Body: Static<T["body"]>;
+      Querystring: Static<T["querystring"]>;
+      Params: Static<T["params"]>;
+      Headers: Static<T["headers"]>;
     },
     ContextConfig = ContextConfigDefault
   >(
@@ -76,10 +76,10 @@ interface TypeboxRouteShorthandMethod<
   <
     T extends Schema,
     RequestGeneric extends {
-      Body?: Static<T["body"]>;
-      Querystring?: Static<T["querystring"]>;
-      Params?: Static<T["params"]>;
-      Headers?: Static<T["headers"]>;
+      Body: Static<T["body"]>;
+      Querystring: Static<T["querystring"]>;
+      Params: Static<T["params"]>;
+      Headers: Static<T["headers"]>;
     },
     ContextConfig = ContextConfigDefault
   >(

--- a/index.ts
+++ b/index.ts
@@ -42,8 +42,8 @@ interface TypeboxRouteShorthandMethod<
     ContextConfig = ContextConfigDefault
   >(
     path: string,
-    opts: Omit<RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>, "schema"> & {
-      schema?: Partial<T>;
+    opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig> & {
+      schema?: T;
     },
     handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
   ): FastifyInstance<RawServer, RawRequest, RawReply>;
@@ -84,8 +84,8 @@ interface TypeboxRouteShorthandMethod<
     ContextConfig = ContextConfigDefault
   >(
     path: string,
-    opts: Omit<RouteShorthandOptionsWithHandler<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>, "schema"> & {
-      schema?: Partial<T>;
+    opts: RouteShorthandOptionsWithHandler<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig> & {
+      schema?: T;
     }
   ): FastifyInstance<RawServer, RawRequest, RawReply>;
 }

--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ import {
   RawServerBase,
   RawServerDefault,
   RouteHandlerMethod,
+  RouteOptions,
   RouteShorthandOptions,
   RouteShorthandOptionsWithHandler
 } from "fastify";
@@ -90,6 +91,16 @@ declare module "fastify" {
     Logger = FastifyLoggerInstance
   > {
     typeboxSchema: typeof createTypeboxSchema;
+
+    route<
+      T extends Schema,
+      RouteGeneric extends InferredRouteInterface<T>,
+      ContextConfig = ContextConfigDefault
+    >(
+      opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> & {
+        schema?: T;
+      }
+    ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
     get: TypeboxRouteShorthandMethod<RawServer, RawRequest, RawReply>;
     head: TypeboxRouteShorthandMethod<RawServer, RawRequest, RawReply>;

--- a/index.ts
+++ b/index.ts
@@ -54,12 +54,11 @@ interface TypeboxRouteShorthandMethod<
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
 > {
   <
-    T extends Schema,
     RequestGeneric extends {
-      Body?: Static<T["body"]>;
-      Querystring?: Static<T["querystring"]>;
-      Params?: Static<T["params"]>;
-      Headers?: Static<T["headers"]>;
+      Body: never;
+      Querystring: never;
+      Params: never;
+      Headers: never;
     },
     ContextConfig = ContextConfigDefault
   >(

--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,13 @@ interface Schema extends FastifySchema {
   };
 }
 
+export interface InferredRouteInterface<T extends Schema> {
+  Body: Static<T["body"]>;
+  Querystring: Static<T["querystring"]>;
+  Params: Static<T["params"]>;
+  Headers: Static<T["headers"]>;
+}
+
 interface TypeboxRouteShorthandMethod<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
@@ -33,12 +40,7 @@ interface TypeboxRouteShorthandMethod<
 > {
   <
     T extends Schema,
-    RequestGeneric extends {
-      Body: Static<T["body"]>;
-      Querystring: Static<T["querystring"]>;
-      Params: Static<T["params"]>;
-      Headers: Static<T["headers"]>;
-    },
+    RequestGeneric extends InferredRouteInterface<T>,
     ContextConfig = ContextConfigDefault
   >(
     path: string,
@@ -55,12 +57,7 @@ interface TypeboxRouteShorthandMethod<
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
 > {
   <
-    RequestGeneric extends {
-      Body: never;
-      Querystring: never;
-      Params: never;
-      Headers: never;
-    },
+    RequestGeneric extends InferredRouteInterface<never>,
     ContextConfig = ContextConfigDefault
   >(
     path: string,
@@ -75,12 +72,7 @@ interface TypeboxRouteShorthandMethod<
 > {
   <
     T extends Schema,
-    RequestGeneric extends {
-      Body: Static<T["body"]>;
-      Querystring: Static<T["querystring"]>;
-      Params: Static<T["params"]>;
-      Headers: Static<T["headers"]>;
-    },
+    RequestGeneric extends InferredRouteInterface<T>,
     ContextConfig = ContextConfigDefault
   >(
     path: string,

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ import {
   RawServerDefault,
   RouteHandlerMethod,
   RouteShorthandOptions,
+  RouteShorthandOptionsWithHandler
 } from "fastify";
 import fp from "fastify-plugin";
 
@@ -83,7 +84,7 @@ interface TypeboxRouteShorthandMethod<
     ContextConfig = ContextConfigDefault
   >(
     path: string,
-    opts: Omit<RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>, "schema"> & {
+    opts: Omit<RouteShorthandOptionsWithHandler<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>, "schema"> & {
       schema?: Partial<T>;
     }
   ): FastifyInstance<RawServer, RawRequest, RawReply>;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "types": "index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "test": "tsc -p test/tsconfig.json",
     "clean": "rimraf index.js index.d.ts",
     "prepublishOnly": "npm run clean && npm run build",
     "postinstall": "npx patch-package --patch-dir ."

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,0 +1,113 @@
+import { Type } from "@sinclair/typebox";
+import { FastifyPluginAsync } from "fastify";
+import fastifyTypebox from "../index";
+
+const plugin: FastifyPluginAsync = async function (fastify, opts) {
+  fastify.register(fastifyTypebox)
+
+  // longhand (opts)
+  fastify.route({
+    method: "GET",
+    url: "/secret-route/:id",
+    schema: {
+      params: Type.Object({
+        id: Type.String(),
+      }),
+      querystring: Type.Object({
+        optionalFilter: Type.Optional(Type.String())
+      }),
+      body: Type.Object({
+        user: Type.Object({
+          name: Type.String(),
+          age: Type.Number({ minimum: 18 }),
+        }),
+      }),
+      response: {
+        200: Type.Object({
+          result: Type.Boolean()
+        }),
+        400: Type.Object({
+          error: Type.String()
+        })
+      }
+    },
+    async handler(request, reply): Promise<{ result: boolean } | { error: string }> {
+      const id: string = request.params.id
+      const filter: string | undefined = request.query.optionalFilter
+      const user: { name: string, age: number } = request.body.user
+      return {
+        result: true
+      }
+    }
+  })
+
+  // shorthand (path, opts, handler)
+  fastify.get(
+    "/secret-route/:id",
+    {
+      schema: {
+        params: Type.Object({
+          id: Type.String(),
+        }),
+        querystring: Type.Object({
+          optionalFilter: Type.Optional(Type.String())
+        }),
+        body: Type.Object({
+          user: Type.Object({
+            name: Type.String(),
+            age: Type.Number({ minimum: 18 }),
+          }),
+        }),
+        response: {
+          // void (HTTP 204)
+        }
+      },
+    },
+    async (request, reply): Promise<void> => {
+      const id: string = request.params.id
+      const filter: string | undefined = request.query.optionalFilter
+      const user: { name: string, age: number } = request.body.user
+    }
+  );
+
+  // shorthand (path, handler) -- no schema!
+  fastify.get(
+    "/secret-route/:id",
+    async (request, reply) => {
+      const p: never = request.params
+    }
+  );
+
+  // shorthand (path, opts+handler)
+  fastify.get(
+    "/secret-route/:id",
+    {
+      schema: {
+        // You can also type querystring, headers and response
+        params: Type.Object({
+          id: Type.String(),
+        }),
+        querystring: Type.Object({
+          optionalFilter: Type.Optional(Type.String())
+        }),
+        body: Type.Object({
+          user: Type.Object({
+            name: Type.String(),
+            age: Type.Number({ minimum: 18 }),
+          }),
+        }),
+        response: {
+          200: Type.String()
+        }
+      },
+      async handler(request, reply): Promise<string> {
+        const id: string = request.params?.id
+        const filter: string | undefined = request.query.optionalFilter
+        const user: { name: string, age: number } = request.body?.user
+        return ''
+      }
+    }
+  );
+};
+
+export default plugin;

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "noEmit": true,
+        "declaration": false,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false
+    },
+    "include": [
+        "**/*.ts"
+    ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -66,5 +66,8 @@
     /* Advanced Options */
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
-  }
+  },
+  "include": [
+    "index.ts"
+  ]
 }


### PR DESCRIPTION
This PR makes a handful of improvements to the types:

### 1. Implement the longhand `fastify.route` method

```ts
fastify.route({
  method: "GET",
  url: "/secret-route/:id",
  schema: {
  },
  async handler(request, reply) {
  }
})
```

### 2. Use the response schema to infer the handler return type

The response type is the union of all the possible `response` values:

```ts
fastify.route({
  method: "GET",
  url: "/secret-route/:id",
  schema: {
    response: {
      200: Type.String(),
      400: Type.Number()
    }
  },
  async handler(request, reply) {
    // return type inferred as Promise<string | number | void>
  }
})
```

### 3. Fix `shorthand(path, opts+handler)` overload

This overload was missing the `handler` option:

```ts
fastify.get(
  "/secret-route/:id",
  {
    schema: {
    },
    async handler(request, reply) {
    }
  }
);
```

### 4. Remove `| undefined` from body, params, etc

You can use `request.params.id` instead of `request.params?.id`. Use `Type.Optional` if you want the param/body/etc to be optional:

```ts
fastify.get(
  "/secret-route/:id",
  {
    schema: {
      params: Type.Object({
        id: Type.String(),
      }),
      querystring: Type.Object({
        optionalFilter: Type.Optional(Type.String())
      }),
    },
  },
  async (request, reply): Promise<void> => {
    const id: string = request.params.id
    const filter: string | undefined = request.query.optionalFilter
  }
);
```

### 5. Add tests

I added a test to ensure that all the above compiles. `npm run test` to compile the test.
